### PR TITLE
Made Smarties class derive from object to get it to work with pickles in python2

### DIFF
--- a/get_smarties.py
+++ b/get_smarties.py
@@ -6,7 +6,7 @@ from pandas.core.frame import DataFrame
 from pandas.core.indexing import is_list_like
 from pandas.core.categorical import _factorize_from_iterable
 
-class Smarties:
+class Smarties(object):
     def __init__(self, main_lookup=None):
         self.main_lookup=main_lookup
         return None


### PR DESCRIPTION
In python2, old-style classes (those not derived from object) don't have `__new__()`. This causes an error when loading a Smarties object from a pickle:
```AttributeError: class Smarties has no attribute '__new__'```

By making Smarties inherit from object, this problem is solved.